### PR TITLE
relax leaflet peer dependency to ^1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "git+https://github.com/cherniavskii/Leaflet.DoubleTapDrag.git"
   },
   "peerDependencies": {
-    "leaflet": "~1.0.0"
+    "leaflet": "^1.0.0"
   },
   "keywords": [
     "leaflet",


### PR DESCRIPTION
Thanks for this plugin!

What do you think about relaxing the peer dependency on leaflet to allow newer minor versions? Currently I have to do a `npm install leaflet-doubletapdrag --legacy-peer-deps` in order to use this with the latest release of leaflet. As far as I can tell there's nothing that breaks when this plugin is used with newer releases of leaflet.

If it is all good I will submit the same change for Leaflet.DoubleTapDragZoom as well :)